### PR TITLE
Fix: Remove requirement for non-null "id" or "lid" on serialization

### DIFF
--- a/jsonapi-adapters/src/main/java/jsonapi/ResourceIdentifier.kt
+++ b/jsonapi-adapters/src/main/java/jsonapi/ResourceIdentifier.kt
@@ -30,9 +30,6 @@ class ResourceIdentifier @JvmOverloads constructor(
     require(type.isNotBlank()) {
       "A resource identifier MUST contain a type member but was blank."
     }
-    require(!id.isNullOrBlank() || !lid.isNullOrBlank()) {
-      "A resource identifier MUST contain an 'id' or 'lid' member but both were null or blank."
-    }
   }
 
   override fun equals(other: Any?): Boolean {

--- a/jsonapi-adapters/src/main/java/jsonapi/ResourceObject.kt
+++ b/jsonapi-adapters/src/main/java/jsonapi/ResourceObject.kt
@@ -31,9 +31,6 @@ class ResourceObject @JvmOverloads constructor(
     require(type.isNotBlank()) {
       "A resource object MUST contain a type member but was blank."
     }
-    require(!id.isNullOrBlank() || !lid.isNullOrBlank()) {
-      "A resource object MUST contain an 'id' or 'lid' member but both were null or blank."
-    }
   }
 
   /** Creates [ResourceIdentifier] from this resource. */

--- a/jsonapi-adapters/src/main/java/jsonapi/internal/ResourceBinder.kt
+++ b/jsonapi-adapters/src/main/java/jsonapi/internal/ResourceBinder.kt
@@ -48,9 +48,6 @@ private fun resourceIdentifier(target: Any): ResourceIdentifier {
 
   val id = getValueOfAnnotatedFieldOrProperty<String>(target, Id::class.java)
   val lid = getValueOfAnnotatedFieldOrProperty<String>(target, Lid::class.java)
-  if (id.isNullOrBlank() && lid.isNullOrBlank()) {
-    throw IllegalArgumentException("A resource MUST contain an 'id' or 'lid' but both were null or blank.")
-  }
 
   return ResourceIdentifier(type, id, lid)
 }

--- a/jsonapi-adapters/src/test/java/jsonapi/internal/ReadResourceObjectTest.kt
+++ b/jsonapi-adapters/src/test/java/jsonapi/internal/ReadResourceObjectTest.kt
@@ -90,6 +90,22 @@ class ReadResourceObjectTest {
     )
   }
 
+  @Test(expected = IllegalArgumentException::class)
+  fun `read throws if target has relationships without identifier`() {
+    @Resource("bar")
+    class Bar(@Id val id: String?, @Lid val lid: String? = null)
+
+    @Resource("foo")
+    class Foo {
+      @Id val id = null
+      @jsonapi.ToOne("A") val a = Bar(null)
+      @jsonapi.ToOne("B") val b = Bar("2")
+      @jsonapi.ToMany("C") val c = listOf(Bar("1"), Bar("2"), Bar("3"))
+    }
+
+    readResourceObject(Foo())
+  }
+
   @Test(expected = IllegalStateException::class)
   fun `read throws if multiple relationship fields are defined for the same name`() {
     @Resource("bar")
@@ -180,6 +196,7 @@ class ReadResourceObjectTest {
     assertThat(resourceObject.lid).isEqualTo("1")
   }
 
+  @Test
   fun `read from target without id or lid`() {
     @Resource("foo")
     class Foo(

--- a/jsonapi-adapters/src/test/java/jsonapi/internal/ReadResourceObjectTest.kt
+++ b/jsonapi-adapters/src/test/java/jsonapi/internal/ReadResourceObjectTest.kt
@@ -68,7 +68,7 @@ class ReadResourceObjectTest {
 
     @Resource("foo")
     class Foo {
-      @Id val id = "1"
+      @Id val id = null
       @jsonapi.ToOne("A") val a = Bar("1")
       @jsonapi.ToOne("B") val b = Bar("2")
       @jsonapi.ToMany("C") val c = listOf(Bar("1"), Bar("2"), Bar("3"))
@@ -180,15 +180,17 @@ class ReadResourceObjectTest {
     assertThat(resourceObject.lid).isEqualTo("1")
   }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `read throws for target with invalid identifier`() {
+  fun `read from target without id or lid`() {
     @Resource("foo")
-    class Foo {
-      @Id val id = ""
-      @Lid val lid = ""
-    }
+    class Foo(
+      @Lid val lid: String? = null,
+      @Id val id: String? = null
+    )
 
-    readResourceObject(Foo())
+    val resourceObject = readResourceObject(Foo())
+
+    assertThat(resourceObject.id).isNull()
+    assertThat(resourceObject.lid).isNull()
   }
 
   @Test(expected = IllegalStateException::class)

--- a/jsonapi-adapters/src/test/java/jsonapi/internal/adapter/ResourceTypeAdapterTest.kt
+++ b/jsonapi-adapters/src/test/java/jsonapi/internal/adapter/ResourceTypeAdapterTest.kt
@@ -307,27 +307,17 @@ class ResourceTypeAdapterTest {
     assertThat(serialized).isEqualTo("""{"type":"articles","id":"1","attributes":{"title":"Title"}}""")
   }
 
+  @Test
+  fun `serialize resource without id or lid`() {
+    val article = Article(id = null, lid = null, title = "Title")
+    val adapter = moshi.adapter(Article::class.java)
+    val serialized = adapter.toJson(article)
+    assertThat(serialized).isEqualTo("""{"type":"articles","attributes":{"title":"Title"}}""")
+  }
+
   @Test(expected = IllegalArgumentException::class)
   fun `throw when serializing resource with invalid type`() {
     val article = Article(type = "", id = "1")
-    adapter.toJson(article)
-  }
-
-  @Test(expected = IllegalArgumentException::class)
-  fun `throw when serializing resource without id or lid`() {
-    val article = Article(type = "articles", id = null, lid = null)
-    adapter.toJson(article)
-  }
-
-  @Test(expected = IllegalArgumentException::class)
-  fun `throw when serializing resource with invalid id`() {
-    val article = Article(type = "articles", id = "", lid = null)
-    adapter.toJson(article)
-  }
-
-  @Test(expected = IllegalArgumentException::class)
-  fun `throw when serializing resource with invalid lid`() {
-    val article = Article(type = "articles", id = null, lid = "")
     adapter.toJson(article)
   }
 


### PR DESCRIPTION
This PR adds proposition for fixing the issue where `id` or `lid` is required during the serialization.

As per [JsonApi specification](https://jsonapi.org/format/#crud-creating), both the `id` or `lid` can be null.
This is important when Resource ID needs to be defined on the backend and backend might reject the POST request if it's not expecting the id to be sent from the client.

**Resource creation**
>A resource can be created by sending a POST request to a URL that represents a collection of resources. The request MUST include a single [resource object](https://jsonapi.org/format/#document-resource-objects) as primary data. The [resource object](https://jsonapi.org/format/#document-resource-objects) MUST contain at least a type member.


**Resource object**
>“Resource objects” appear in a JSON:API document to represent resources.
>A resource object MUST contain at least the following top-level members:
>- id
>- type
>
>**Exception: The id member is not required when the resource object originates at the client and represents a new resource to be created on the server.**