### PR TITLE
RelationshipsBinder: support binding just the ID

### DIFF
--- a/jsonapi-adapters/src/main/java/jsonapi/internal/RelationshipsBinder.kt
+++ b/jsonapi-adapters/src/main/java/jsonapi/internal/RelationshipsBinder.kt
@@ -38,6 +38,10 @@ private fun bindRelationshipFields(
     when (relationship) {
       is Relationship.ToOne -> {
         val resourceIdentifier = relationship.data ?: return@forEach
+        if (field.type == String::class.java) {
+          field.setValue(target, resourceIdentifier.id)
+          return@forEach
+        }
         val matchedPair = resources.find { it.first.identifier() == resourceIdentifier }
         val matchedResource = matchedPair?.second ?: return@forEach
         try {
@@ -71,6 +75,11 @@ private fun bindRelationshipFields(
         if (field.type == Collection::class.java || field.type == List::class.java) {
           // Assert that matched resources are assignable to field
           val fieldElementType = field.genericType.collectionElementType(Collection::class.java).rawType()
+          if (fieldElementType == String::class.java) {
+            field.setValue(target, relationship.data.map { it.id })
+            return@forEach
+          }
+
           val nonMatchingResource = matchedResources.find { !fieldElementType.isAssignableFrom(it::class.java) }
           if (nonMatchingResource == null) {
             // All resources are assignable to declared field type - set field via reflection


### PR DESCRIPTION
In case the JSON:API server does not send an `"included"` section that includes all referenced objects, it would be helpful to also be able to just bind the ID of an object referenced with a `ToOne` or `ToMany` relationship to a field in the Kotlin class.

This PR implements this feature by checking if the type of the field annotated with `@ToOne` or `@ToMany` is `String`, and if yes, it simply assigns `resourceIdentifier.id` to that field instead of trying to find a matching resource in the `"resources"` or `"included"` sections.